### PR TITLE
Json => TS: First character of "property" should remain the same

### DIFF
--- a/src/Json2Ts.ts
+++ b/src/Json2Ts.ts
@@ -146,7 +146,8 @@ export class Json2Ts {
     };
 
     private toLowerFirstLetter(text: string) {
-        return text.charAt(0).toLowerCase() + text.slice(1);
+        //return text.charAt(0).toLowerCase() + text.slice(1);
+        return text;
     };
 }
 

--- a/src/Json2Ts.ts
+++ b/src/Json2Ts.ts
@@ -120,9 +120,9 @@ export class Json2Ts {
         for (let index = 0, length = allKeys.length; index < length; index++) {
             let key = allKeys[index];
             if (_.contains(optionalKeys, key)) {
-                result = result.replace(new RegExp(key + ":", "g"), this.toLowerFirstLetter(key) + "?:");
+                result = result.replace(new RegExp(key + ":", "g"), key + "?:");
             } else {
-                result = result.replace(new RegExp(key + ":", "g"), this.toLowerFirstLetter(key) + ":");
+                result = result.replace(new RegExp(key + ":", "g"), key + ":");
             }
         }
 
@@ -145,10 +145,7 @@ export class Json2Ts {
         return text.charAt(0).toUpperCase() + text.slice(1);
     };
 
-    private toLowerFirstLetter(text: string) {
-        //return text.charAt(0).toLowerCase() + text.slice(1);
-        return text;
-    };
+    
 }
 
 export function isJson(stringContent) {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -93,6 +93,7 @@ suite("json2ts Tests", () => {
 
         assert.equal(result, ts);
     });
+    
 
     test("Convert JSON-Value to Number[][]-Type", () => {
         let json = `{\n\t"multiarrays": [[4, 3], [2, 1]]\n}`;
@@ -103,6 +104,7 @@ suite("json2ts Tests", () => {
 
         assert.equal(result, ts);
     });
+
 
     test("Convert JSON-Value to Boolean[][]-Type", () => {
         let json = `{\n\t"multiarrays": [[true, false], [false, false]]\n}`;
@@ -156,7 +158,7 @@ suite("json2ts Tests", () => {
 
     test("Convert JSON-Value to String-Type (Key is lower)", () => {
         let json = `{\n\t"Name": "Mustermann"\n}`;
-        let ts = `export interface RootObject {\n\tname: string;\n}`;
+        let ts = `export interface RootObject {\n\tName: string;\n}`;
 
         let json2ts = new Json2Ts();
         let result = json2ts.convert(json);
@@ -174,9 +176,10 @@ suite("json2ts Tests", () => {
         assert.equal(result, ts);
     });
 
+
     test("Convert extensive JSON-Value to TypeScript Interfaces", () => {
         let json = `{\n\t"Herausgeber": "Xema","Nummer": "1234-5678-9012-3456","Deckung": 2e+6,"Waehrung": "EURO","Inhaber": {\n\t"Name": "Mustermann","Vorname": "Max","maennlich": true,"Hobbys": [ "Reiten", "Golfen", "Lesen" ], "Alter": 42,"Kinder": [],"Partner": null\n\t}\n}`;
-        let ts = `export interface Inhaber {\n\tname: string;\n\tvorname: string;\n\tmaennlich: boolean;\n\thobbys: string[];\n\talter: number;\n\tkinder: any[];\n\tpartner?: any;\n}\n\nexport interface RootObject {\n\therausgeber: string;\n\tnummer: string;\n\tdeckung: number;\n\twaehrung: string;\n\tinhaber: Inhaber;\n}`;
+        let ts = `export interface Inhaber {\n\tName: string;\n\tVorname: string;\n\tmaennlich: boolean;\n\tHobbys: string[];\n\tAlter: number;\n\tKinder: any[];\n\tPartner?: any;\n}\n\nexport interface RootObject {\n\tHerausgeber: string;\n\tNummer: string;\n\tDeckung: number;\n\tWaehrung: string;\n\tInhaber: Inhaber;\n}`;
 
         let json2ts = new Json2Ts();
         let result = json2ts.convert(json);


### PR DESCRIPTION
Hello,

currently the addIn converts
{"ABC" : "hello"} 
to
export interface RootObject {
        aBC: string;
    }

The Website json2ts.com creates another interface:

export interface RootObject {
        ABC: string;
 }

If you use the changed code the first character shall remain the same as in the json result.
